### PR TITLE
 to correct divide by zero error on pm-cpu intel debug

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1491,8 +1491,11 @@
 !
 ! Old definitions:  MSCX(JSEA)  = ABX2(JSEA) * FACTOR * FACTOR2
 !                   MSCY(JSEA)  = ABY2(JSEA) * FACTOR * FACTOR2
-            MSCD(JSEA)=0.5*ATAN2(2*MB,MA-MC)
-
+            if (MB .eq. 0.) then
+              MSCD(JSEA)=0.5*ATAN2(1.0e-15,MA-MC)
+            else
+              MSCD(JSEA)=0.5*ATAN2(2*MB,MA-MC)
+            endif
             MSCX(JSEA)= MA*COS(MSCD(JSEA))**2   &
                        +2*MB*SIN(MSCD(JSEA))*COS(MSCD(JSEA))+MA*SIN(MSCD(JSEA))**2
             MSCY(JSEA)= MC*COS(MSCD(JSEA))**2   &
@@ -1802,7 +1805,11 @@
 !     From matlab script: t0=0.5*(atan2(2.*B,A-C));
 !     From matlab script: A2=A.*cos(t0).^2+2.*B.*sin(t0).*cos(t0)+A.*cos(t0).^2+C.*sin(t0)^2;
 !     From matlab script: C2=C.*cos(t0)^2-2.*B.*sin(t0).*cos(t0)+A.*sin(t0).^2;
-         MSSD(JSEA)=0.5*(ATAN2(2*ETXY(JSEA),ETXX(JSEA)-ETYY(JSEA)))
+         if (ETXY(JSEA) .eq. 0.) then
+           MSSD(JSEA)=0.5*(ATAN2(1.0e-15,ETXX(JSEA)-ETYY(JSEA)))
+         else
+           MSSD(JSEA)=0.5*(ATAN2(2*ETXY(JSEA),ETXX(JSEA)-ETYY(JSEA)))
+         endif
          MSSX(JSEA)  = ETXX(JSEA)*COS(MSSD(JSEA))**2   &
                        +2*ETXY(JSEA)*SIN(MSSD(JSEA))*COS(MSSD(JSEA))+ETYY(JSEA)*SIN(MSSD(JSEA))**2
          MSSY(JSEA)  = ETYY(JSEA)*COS(MSSD(JSEA))**2   &

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1491,11 +1491,7 @@
 !
 ! Old definitions:  MSCX(JSEA)  = ABX2(JSEA) * FACTOR * FACTOR2
 !                   MSCY(JSEA)  = ABY2(JSEA) * FACTOR * FACTOR2
-            if (MB .eq. 0.) then
-              MSCD(JSEA)=0.5*ATAN2(1.0e-15,MA-MC)
-            else
-              MSCD(JSEA)=0.5*ATAN2(2*MB,MA-MC)
-            endif
+            MSCD(JSEA)=0.5*ATAN2((2*MB)+1.0e-15,MA-MC)
             MSCX(JSEA)= MA*COS(MSCD(JSEA))**2   &
                        +2*MB*SIN(MSCD(JSEA))*COS(MSCD(JSEA))+MA*SIN(MSCD(JSEA))**2
             MSCY(JSEA)= MC*COS(MSCD(JSEA))**2   &
@@ -1805,11 +1801,7 @@
 !     From matlab script: t0=0.5*(atan2(2.*B,A-C));
 !     From matlab script: A2=A.*cos(t0).^2+2.*B.*sin(t0).*cos(t0)+A.*cos(t0).^2+C.*sin(t0)^2;
 !     From matlab script: C2=C.*cos(t0)^2-2.*B.*sin(t0).*cos(t0)+A.*sin(t0).^2;
-         if (ETXY(JSEA) .eq. 0.) then
-           MSSD(JSEA)=0.5*(ATAN2(1.0e-15,ETXX(JSEA)-ETYY(JSEA)))
-         else
-           MSSD(JSEA)=0.5*(ATAN2(2*ETXY(JSEA),ETXX(JSEA)-ETYY(JSEA)))
-         endif
+         MSSD(JSEA)=0.5*(ATAN2((2*ETXY(JSEA))+1.0e15,ETXX(JSEA)-ETYY(JSEA)))
          MSSX(JSEA)  = ETXX(JSEA)*COS(MSSD(JSEA))**2   &
                        +2*ETXY(JSEA)*SIN(MSSD(JSEA))*COS(MSSD(JSEA))+ETYY(JSEA)*SIN(MSSD(JSEA))**2
          MSSY(JSEA)  = ETYY(JSEA)*COS(MSSD(JSEA))**2   &

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1279,6 +1279,8 @@
       ETXX   = 0.
       ETYY   = 0.
       ETXY   = 1.0e-15
+      !initalizing this to small non-zero value to avoid 'divide by
+      !zero' error in ATAN2 Calcualtion below 
       ABR    = 0.
       ABA    = 0.
       ABD    = 0.
@@ -1375,6 +1377,8 @@
         ABYY   = 0.
         ABXY   = 0.
         ABYX   = 1.0e-15
+        ! initalizing this to small non-zero value to avoid 'divide by
+        ! zero' error in ATAN2 Calcualtion below
         ABST   = 0.
 !
 ! 2.b Integrate energy in band

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1278,7 +1278,7 @@
       ETY    = 0.
       ETXX   = 0.
       ETYY   = 0.
-      ETXY   = 0.
+      ETXY   = 1.0e-15
       ABR    = 0.
       ABA    = 0.
       ABD    = 0.
@@ -1374,7 +1374,7 @@
         ABXX   = 0.
         ABYY   = 0.
         ABXY   = 0.
-        ABYX   = 0.
+        ABYX   = 1.0e-15
         ABST   = 0.
 !
 ! 2.b Integrate energy in band
@@ -1491,7 +1491,7 @@
 !
 ! Old definitions:  MSCX(JSEA)  = ABX2(JSEA) * FACTOR * FACTOR2
 !                   MSCY(JSEA)  = ABY2(JSEA) * FACTOR * FACTOR2
-            MSCD(JSEA)=0.5*ATAN2((2*MB)+1.0e-15,MA-MC)
+            MSCD(JSEA)=0.5*ATAN2(2*MB,MA-MC)
             MSCX(JSEA)= MA*COS(MSCD(JSEA))**2   &
                        +2*MB*SIN(MSCD(JSEA))*COS(MSCD(JSEA))+MA*SIN(MSCD(JSEA))**2
             MSCY(JSEA)= MC*COS(MSCD(JSEA))**2   &
@@ -1801,7 +1801,7 @@
 !     From matlab script: t0=0.5*(atan2(2.*B,A-C));
 !     From matlab script: A2=A.*cos(t0).^2+2.*B.*sin(t0).*cos(t0)+A.*cos(t0).^2+C.*sin(t0)^2;
 !     From matlab script: C2=C.*cos(t0)^2-2.*B.*sin(t0).*cos(t0)+A.*sin(t0).^2;
-         MSSD(JSEA)=0.5*(ATAN2((2*ETXY(JSEA))+1.0e15,ETXX(JSEA)-ETYY(JSEA)))
+         MSSD(JSEA)=0.5*(ATAN2(2*ETXY(JSEA),ETXX(JSEA)-ETYY(JSEA)))
          MSSX(JSEA)  = ETXX(JSEA)*COS(MSSD(JSEA))**2   &
                        +2*ETXY(JSEA)*SIN(MSSD(JSEA))*COS(MSSD(JSEA))+ETYY(JSEA)*SIN(MSSD(JSEA))**2
          MSSY(JSEA)  = ETYY(JSEA)*COS(MSSD(JSEA))**2   &

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1496,6 +1496,7 @@
 ! Old definitions:  MSCX(JSEA)  = ABX2(JSEA) * FACTOR * FACTOR2
 !                   MSCY(JSEA)  = ABY2(JSEA) * FACTOR * FACTOR2
             MSCD(JSEA)=0.5*ATAN2(2*MB,MA-MC)
+
             MSCX(JSEA)= MA*COS(MSCD(JSEA))**2   &
                        +2*MB*SIN(MSCD(JSEA))*COS(MSCD(JSEA))+MA*SIN(MSCD(JSEA))**2
             MSCY(JSEA)= MC*COS(MSCD(JSEA))**2   &

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -207,6 +207,8 @@
       DLWMEAN =0.
       ELCS =0.
       ELSN =1.0e-15
+       ! initalize this to a small non-zero value to avoid 'divide by
+       ! zero' error in ATAN2 Calcualtion of DLWMEAN below 
 !
 ! 1.  Integral over directions and maximum --------------------------- *
 !
@@ -1732,7 +1734,9 @@
           MSSP   = 0.
           MSSPC2 = 0.
           MSSPS2 = 0.
-          MSSPCS = 1.0e-15
+          MSSPCS = 1.0e-15 
+         ! initalize this to a small, non-zero value to avoid 'divide by
+         ! zero' error in ATAN2 Calcualtion of MSSD below. 
 !
 ! Sums the contributions to the directional MSS for all ITH   
 !

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -222,8 +222,11 @@
           AMAX   = MAX ( AMAX , A(ITH,IK) )
           END DO
         END DO
-
-        DLWMEAN=ATAN2(ELSN,ELCS);
+        IF (ELSN.eq.0.) THEN
+          DLWMEAN=ATAN2(1.0e-15,ELCS);
+        ELSE
+          DLWMEAN=ATAN2(ELSN,ELCS);
+        ENDIF
 !
 ! 2.  Integrate over directions -------------------------------------- *
 !
@@ -1760,8 +1763,12 @@
           MSSSUM  (IK:NK,5) = MSSSUM (IK:NK,5) +MSSPCS
 !
 ! Direction of long wave mss summed up to IK       
-!
-          MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
+!  
+         IF (MSSSUM(IK,5).eq.0.) THEN
+            MSSD=0.5*(ATAN2(1.0e-15,MSSSUM(IK,3)-MSSSUM(IK,4)))
+          ELSE
+            MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
+          ENDIF
           IF (MSSD.LT.0) MSSD = MSSD + PI
             IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)
 !

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -224,6 +224,7 @@
           AMAX   = MAX ( AMAX , A(ITH,IK) )
           END DO
         END DO
+
         DLWMEAN=ATAN2(ELSN,ELCS);
 !
 ! 2.  Integrate over directions -------------------------------------- *
@@ -1763,7 +1764,7 @@
           MSSSUM  (IK:NK,5) = MSSSUM (IK:NK,5) +MSSPCS
 !
 ! Direction of long wave mss summed up to IK       
-!  
+! 
           MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
           IF (MSSD.LT.0) MSSD = MSSD + PI
             IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -206,7 +206,7 @@
       AMAX   = 0.
       DLWMEAN =0.
       ELCS =0.
-      ELSN =0.
+      ELSN =1.0e-15
 !
 ! 1.  Integral over directions and maximum --------------------------- *
 !
@@ -222,7 +222,7 @@
           AMAX   = MAX ( AMAX , A(ITH,IK) )
           END DO
         END DO
-        DLWMEAN=ATAN2(ELSN+1.0e-15,ELCS);
+        DLWMEAN=ATAN2(ELSN,ELCS);
 !
 ! 2.  Integrate over directions -------------------------------------- *
 !
@@ -1732,7 +1732,7 @@
           MSSP   = 0.
           MSSPC2 = 0.
           MSSPS2 = 0.
-          MSSPCS = 0.
+          MSSPCS = 1.0e-15
 !
 ! Sums the contributions to the directional MSS for all ITH   
 !
@@ -1760,7 +1760,7 @@
 !
 ! Direction of long wave mss summed up to IK       
 !  
-          MSSD=0.5*(ATAN2((2*MSSSUM(IK,5))+1.0e-15,MSSSUM(IK,3)-MSSSUM(IK,4)))
+          MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
           IF (MSSD.LT.0) MSSD = MSSD + PI
             IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)
 !

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -222,11 +222,7 @@
           AMAX   = MAX ( AMAX , A(ITH,IK) )
           END DO
         END DO
-        IF (ELSN.eq.0.) THEN
-          DLWMEAN=ATAN2(1.0e-15,ELCS);
-        ELSE
-          DLWMEAN=ATAN2(ELSN,ELCS);
-        ENDIF
+        DLWMEAN=ATAN2(ELSN+1.0e-15,ELCS);
 !
 ! 2.  Integrate over directions -------------------------------------- *
 !
@@ -1764,11 +1760,7 @@
 !
 ! Direction of long wave mss summed up to IK       
 !  
-         IF (MSSSUM(IK,5).eq.0.) THEN
-            MSSD=0.5*(ATAN2(1.0e-15,MSSSUM(IK,3)-MSSSUM(IK,4)))
-          ELSE
-            MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
-          ENDIF
+          MSSD=0.5*(ATAN2((2*MSSSUM(IK,5))+1.0e-15,MSSSUM(IK,3)-MSSSUM(IK,4)))
           IF (MSSD.LT.0) MSSD = MSSD + PI
             IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)
 !

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -1764,7 +1764,7 @@
           MSSSUM  (IK:NK,5) = MSSSUM (IK:NK,5) +MSSPCS
 !
 ! Direction of long wave mss summed up to IK       
-! 
+!
           MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
           IF (MSSD.LT.0) MSSD = MSSD + PI
             IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)


### PR DESCRIPTION
# Pull Request Summary
This draft PR adds fixes to WW3 that occurs only on perlmutter-cpu using the intel compiler in debug mode when running an E3SM simulation with cold start WW3 (all E3SM runs at the current moment). 
Several location in the WW3 code calculate the Arc-Tangent between two values - in a cold start simulation, this leads to several divide-by-zero situations that only seem to occur in debug mode, on perlmutter-cpu, using the intel compiler. 

This PR initializes the 'offending' variable to a small, non-zero value (1.0e-15) as opposed to 0.0. This avoids the divide by zero error when debug flag is used, and produces EXACTLY the same results as the original code.
NCDIFF between the control run and this code produces 0.0 in all fields after 1 month. 

