### PR TITLE
ADD Z0 and USTAR2 to output for E3SM Coupling

### DIFF
--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -131,6 +131,8 @@
 !      WNMEAN    R.A.  Public   Mean wave number
 !
 !      CHARN     R.A.  Public   Charnock parameter for air-sea friction.
+!      Z0        R.A.  Public   Sfc Roughness Length for E3SM Coupling
+!      USTAR2    R.A.  Public   Friction Velocity for E3SM coupling
 !      TWS       R.A.  Public   Wind sea period (used for flux parameterizations)
 !      CGE       R.A.  Public   Energy flux.
 !      PHIAW     R.A.  Public   Wind to wave energy flux.
@@ -417,10 +419,12 @@
 !
 ! Output fields group 5)
 !
-        REAL, POINTER         ::  CHARN(:),  CGE(:),  PHIAW(:),       &
+        REAL, POINTER         ::  CHARN(:), Z0(:), USTAR2(:),         &
+                                  CGE(:),  PHIAW(:),                  &
                                   TAUWIX(:),  TAUWIY(:),  TAUWNX(:),  &
                                   TAUWNY(:),  WHITECAP(:,:), TWS(:)
-        REAL, POINTER         :: XCHARN(:), XCGE(:), XPHIAW(:),       &
+        REAL, POINTER         :: XCHARN(:), XZ0(:) , XUSTAR2(:),      &
+                                 XCGE(:), XPHIAW(:),                  &
                                  XTAUWIX(:), XTAUWIY(:), XTAUWNX(:),  &
                                  XTAUWNY(:), XWHITECAP(:,:), XTWS(:)
 !
@@ -576,7 +580,8 @@
                                  PTHP0(:,:), PQP(:,:), PPE(:,:),      &
                                  PTM1(:,:), PT1(:,:), PT2(:,:),PEP(:,:)
 !
-      REAL, POINTER           :: CHARN(:), CGE(:), PHIAW(:),          &
+      REAL, POINTER           :: CHARN(:), Z0(:), USTAR2(:),          &
+                                 CGE(:), PHIAW(:),                    &
                                  TAUWIX(:), TAUWIY(:), TAUWNX(:),     &
                                  TAUWNY(:), WHITECAP(:,:), TWS(:)
 !
@@ -1155,6 +1160,8 @@
 !    Friction velocity UST and USTDIR in W3WDATMD
 !
       ALLOCATE ( WADATS(IMOD)%CHARN   (NSEALM),                       &
+                 WADATS(IMOD)%Z0      (NSEALM),                       &
+                 WADATS(IMOD)%USTAR2  (NSEALM),                       &
                  WADATS(IMOD)%TWS     (NSEALM),                       &
                  WADATS(IMOD)%CGE     (NSEALM),                       &
                  WADATS(IMOD)%PHIAW   (NSEALM),                       &
@@ -1167,6 +1174,8 @@
       CHECK_ALLOC_STATUS ( ISTAT )
 !
       WADATS(IMOD)%CHARN    = UNDEF
+      WADATS(IMOD)%Z0       = UNDEF
+      WADATS(IMOD)%USTAR2   = UNDEF
       WADATS(IMOD)%TWS      = UNDEF
       WADATS(IMOD)%CGE      = UNDEF
       WADATS(IMOD)%PHIAW    = UNDEF
@@ -2058,8 +2067,26 @@
           ALLOCATE ( WADATS(IMOD)%XTWS(1), STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
         END IF
+
+      IF ( OUTFLAGS( 5, 12) ) THEN
+          ALLOCATE ( WADATS(IMOD)%XZ0(NXXX), STAT=ISTAT )
+          CHECK_ALLOC_STATUS ( ISTAT )
+        ELSE
+          ALLOCATE ( WADATS(IMOD)%XZ0(1), STAT=ISTAT )
+          CHECK_ALLOC_STATUS ( ISTAT )
+        END IF
+
+      IF ( OUTFLAGS( 5, 13) ) THEN
+          ALLOCATE ( WADATS(IMOD)%XUSTAR2(NXXX), STAT=ISTAT )
+          CHECK_ALLOC_STATUS ( ISTAT )
+        ELSE
+          ALLOCATE ( WADATS(IMOD)%XUSTAR2(1), STAT=ISTAT )
+          CHECK_ALLOC_STATUS ( ISTAT )
+        END IF
 !
       WADATS(IMOD)%XCHARN    = UNDEF
+      WADATS(IMOD)%XZ0       = UNDEF
+      WADATS(IMOD)%XUSTAR2   = UNDEF
       WADATS(IMOD)%XTWS      = UNDEF
       WADATS(IMOD)%XCGE      = UNDEF
       WADATS(IMOD)%XPHIAW    = UNDEF
@@ -2890,6 +2917,8 @@
           PEP    => WADATS(IMOD)%PEP
 !
           CHARN    => WADATS(IMOD)%CHARN
+          Z0       => WADATS(IMOD)%Z0
+          USTAR2   => WADATS(IMOD)%USTAR2
           TWS      => WADATS(IMOD)%TWS
           CGE      => WADATS(IMOD)%CGE
           PHIAW    => WADATS(IMOD)%PHIAW
@@ -3228,6 +3257,8 @@
           PEP    => WADATS(IMOD)%XPEP
 !
           CHARN    => WADATS(IMOD)%XCHARN
+          Z0       => WADATS(IMOD)%XZ0
+          USTAR2   => WADATS(IMOD)%XUSTAR2
           TWS      => WADATS(IMOD)%XTWS
           CGE      => WADATS(IMOD)%XCGE
           PHIAW    => WADATS(IMOD)%XPHIAW

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1209,7 +1209,7 @@
                           SYY, SXY, PHS, PTP, PLP, PDIR, PSI, PWS,    &
                           PWST, PNR, USERO, TUSX, TUSY, PRMS, TPMS,   &
                           USSX, USSY, MSSX, MSSY, MSSD, MSCX, MSCY,   &
-                          MSCD, CHARN,                                &
+                          MSCD, CHARN, Z0, USTAR2,                    &
                           BHD, CGE, P2SMS, US3D, EF, TH1M, STH1M,     &
                           TH2M, STH2M, HSIG, STMAXE, STMAXD,          &
                           HCMAXE, HMAXE, HCMAXD, HMAXD, USSP, QP, PQP,&
@@ -2596,7 +2596,7 @@
                           CFLXYMAX, CFLTHMAX, CFLKMAX, P2SMS, US3D,    &
                           TH1M, STH1M, TH2M, STH2M, HSIG, PHICE, TAUICE,&
                           STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD, HCMAXD,&
-                          USSP, TAUOCX, TAUOCY
+                          USSP, TAUOCX, TAUOCY, Z0, USTAR2 
 !/
       USE W3ODATMD, ONLY: NOGRP, NGRPP, IDOUT, UNDEF, NDST, NDSE,     &
                           FLOGRD, IPASS => IPASS1, WRITE => WRITE1,   &
@@ -2915,6 +2915,8 @@
                 IF ( FLOGRD( 5, 8) ) WHITECAP(ISEA,2) = UNDEF
                 IF ( FLOGRD( 5, 9) ) WHITECAP(ISEA,3) = UNDEF
                 IF ( FLOGRD( 5,10) ) WHITECAP(ISEA,4) = UNDEF
+                IF ( FLOGRD( 5,12) ) Z0(ISEA) = UNDEF
+                IF ( FLOGRD( 5,13) ) USTAR2(ISEA) = UNDEF
 !
                 IF ( FLOGRD( 6, 1) ) THEN
                                      SXX   (ISEA) = UNDEF
@@ -3232,6 +3234,10 @@
                     WRITE ( NDSOG ) WHITECAP(1:NSEA,4)
                   ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 11 ) THEN
                     WRITE ( NDSOG ) TWS(1:NSEA)
+                  ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 12 ) THEN
+                    WRITE ( NDSOG ) Z0(1:NSEA)
+                  ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 13 ) THEN
+                    WRITE ( NDSOG ) USTAR2(1:NSEA)
 !
 !     Section 6)
 !
@@ -3553,6 +3559,12 @@
                   ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 11 ) THEN
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
                                                    TWS(1:NSEA)
+                  ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 12 ) THEN
+                    READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
+                                                   Z0(1:NSEA)
+                  ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 13 ) THEN
+                    READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
+                                                   USTAR2(1:NSEA)
 !
 !     Section 6)
 !

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -846,7 +846,7 @@
 !
 ! 5) Atmosphere-waves layer
 !
-      NOGE(5) = 11
+      NOGE(5) = 13
 !
       IDOUT( 5, 1)  = 'Friction velocity   '
       IDOUT( 5, 2)  = 'Charnock parameter  '
@@ -860,6 +860,8 @@
       IDOUT( 5,10)  = 'Dominant break prob '
       IDOUT( 5,11)  = 'Wind sea period' ! C.Bunney - reinstated this as is used in ww3_ounf
                                         ! Is it suposed to be defunct? It is not in ww3_outf...
+      IDOUT( 5, 12)  = 'Sfc Rough. Length  '
+      IDOUT( 5, 13)  = 'Friction Velocity  '
 !
 ! 6) Wave-ocean layer
 !

--- a/model/src/w3src4md.F90
+++ b/model/src/w3src4md.F90
@@ -88,7 +88,8 @@
                     TAUA, TAUADIR, DAIR,                              &
 #endif
                     USTAR, USDIR,                                     &
-                    TAUWX, TAUWY, CD, Z0, CHARN, LLWS, FMEANWS, DLWMEAN)
+                    TAUWX, TAUWY, CD, Z0, CHARN, USTAR2,              &
+                    LLWS, FMEANWS, DLWMEAN)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III                SHOM |
@@ -136,6 +137,7 @@
 !       CD      Real  O   Drag coefficient at wind level ZWND.
 !       Z0      Real  O   Corresponding z0.
 !       CHARN   Real  O   Corresponding Charnock coefficient
+!       USTAR2  Real I/O  Friction velocity for E3SM coupling
 !       LLWS    L.A.  I   Wind sea true/false array for each component            
 !       FMEANWS Real  O   Mean frequency of wind sea, used for tail 
 !       DLWMEAN Real  O   Mean Long wave direction  (L. Romero 2019)
@@ -196,9 +198,10 @@
 #endif
       REAL, INTENT(IN)        :: TAUWX, TAUWY
       LOGICAL, INTENT(IN)     :: LLWS(NSPEC)
-      REAL, INTENT(INOUT)     :: USTAR ,USDIR
+      REAL, INTENT(INOUT)     :: USTAR, USDIR
       REAL, INTENT(OUT)       :: EMEAN, FMEAN, FMEAN1, WNMEAN, AMAX,  & 
-                                 CD, Z0, CHARN, FMEANWS, DLWMEAN
+                                 CD, Z0, CHARN, FMEANWS, DLWMEAN,     &
+                                 USTAR2
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -306,6 +309,7 @@
       CALL CALC_USTAR(U,TAUW,USTAR,Z0,CHARN) 
       UNZ    = MAX ( 0.01 , U )
       CD     = (USTAR/UNZ)**2
+      USTAR2 = USTAR
       USDIR = UDIR
 #endif
 !

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -61,7 +61,8 @@
                           REFLEC, REFLED, DELX, DELY, DELA, TRNX,     &
                           TRNY, BERG, FPI, DTDYN, FCUT, DTG, TAUWX,   &
                           TAUWY, TAUOX, TAUOY, TAUWIX, TAUWIY, TAUWNX,&
-                          TAUWNY, PHIAW, CHARN, TWS, PHIOC, WHITECAP, &
+                          TAUWNY, PHIAW, CHARN, Z0, USTAR2,           &
+                          TWS, PHIOC, WHITECAP, &
                           D50, PSIC, BEDFORM , PHIBBL, TAUBBL, TAUICE,&
                           PHICE, TAUOCX, TAUOCY, WNMEAN, DAIR, COEF)
 !/
@@ -224,6 +225,9 @@
 !       TAUOCX-YReal   O   Total ocean momentum components
 !       WNMEAN  Real   O   Mean wave number
 !       DAIR    Real   I   Air density
+!       CHARN   Real  I/O  Charnock parameter 
+!       Z0      Real  I/O  Sfc Roughness Length
+!       USTAR2  Real  I/O  Friction Vel for E3SM Coupling
 !     ----------------------------------------------------------------
 !       Note: several pars are set to I/O to avoid compiler warnings.
 !
@@ -530,7 +534,8 @@
                                  SPEC(NSPEC), ALPHA(NK), USTAR,       &
                                  USTDIR, FPI, TAUOX, TAUOY,           &
                                  TAUWX, TAUWY, PHIAW, PHIOC, PHICE,   &
-                                 CHARN, TWS, BEDFORM(3), PHIBBL,      &
+                                 CHARN, Z0, USTAR2,                   &
+                                 TWS, BEDFORM(3), PHIBBL,             &
                                  TAUBBL(2), TAUICE(2), WHITECAP(4),   &
                                  TAUWIX, TAUWIY, TAUWNX, TAUWNY,      &
                                  ICEF, TAUOCX, TAUOCY, WNMEAN
@@ -559,7 +564,7 @@
                                  HDT, ZWND, FP, DEPTH, TAUSCX, TAUSCY, FHIGI
 ! Scaling factor for SIN, SDS, SNL
       REAL                    :: ICESCALELN, ICESCALEIN, ICESCALENL, ICESCALEDS
-      REAL                    :: EMEAN, FMEAN, AMAX, CD, Z0, SCAT,    &
+      REAL                    :: EMEAN, FMEAN, AMAX, CD, SCAT,    &
                                  SMOOTH_ICEDISP
       REAL                    :: WN_R(NK), CG_ICE(NK),ALPHA_LIU(NK), ICECOEF2,&
                                  R(NK)
@@ -843,6 +848,8 @@
       NSTEPS = 0
       PHIAW  = 0.
       CHARN  = 0.
+      Z0     = 0.
+      USTAR2 = 0.
       TWS    = 0.
       PHINL  = 0.
       PHIBBL = 0.
@@ -937,7 +944,8 @@
                   TAUA, TAUADIR, DAIR,                             &
 #endif
                    USTAR, USTDIR,                                  &
-                   TAUWX, TAUWY, CD, Z0, CHARN, LLWS, FMEANWS, DLWMEAN)
+                   TAUWX, TAUWY, CD, Z0, CHARN, USTAR2,            &
+                   LLWS, FMEANWS, DLWMEAN)
 #endif
 
 #ifdef W3_DEBUGSRC
@@ -980,7 +988,8 @@
                    TAUA, TAUADIR, DAIR,                    &
 #endif
                    USTAR, USTDIR,                                &
-                   TAUWX, TAUWY, CD, Z0, CHARN, LLWS, FMEANWS, DLWMEAN)
+                   TAUWX, TAUWY, CD, Z0, CHARN, USTAR2,          &
+                   LLWS, FMEANWS, DLWMEAN)
       TWS = 1./FMEANWS
 #endif
 #ifdef W3_ST6
@@ -1636,7 +1645,8 @@
                    TAUA, TAUADIR, DAIR,                     &
 #endif
                    USTAR, USTDIR,                                 &
-                   TAUWX, TAUWY, CD, Z0, CHARN, LLWS, FMEANWS, DLWMEAN)
+                   TAUWX, TAUWY, CD, Z0, CHARN, USTAR2,           &
+                   LLWS, FMEANWS, DLWMEAN)
 #endif
 #ifdef W3_ST6
         CALL W3SPR6 (SPEC, CG1, WN1, EMEAN, FMEAN, WNMEAN, AMAX, FP)

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1889,6 +1889,7 @@
                    TAUOX(JSEA), TAUOY(JSEA), TAUWIX(JSEA),        &
                    TAUWIY(JSEA), TAUWNX(JSEA),                    &
                    TAUWNY(JSEA),  PHIAW(JSEA), CHARN(JSEA),       &
+                   Z0(JSEA), USTAR2(JSEA),                        &
                    TWS(JSEA), PHIOC(JSEA), TMP1, D50, PSIC, TMP2, &
                    PHIBBL(JSEA), TMP3, TMP4, PHICE(JSEA),         &
                    TAUOCX(JSEA), TAUOCY(JSEA), WNMEAN(JSEA),      &
@@ -2733,6 +2734,7 @@
                       TAUOX(JSEA), TAUOY(JSEA), TAUWIX(JSEA),     &
                       TAUWIY(JSEA), TAUWNX(JSEA),                 &
                       TAUWNY(JSEA),  PHIAW(JSEA), CHARN(JSEA),    &
+                      Z0(JSEA), USTAR2(JSEA),                     &
                       TWS(JSEA),PHIOC(JSEA), TMP1, D50, PSIC, TMP2,&
                       PHIBBL(JSEA), TMP3, TMP4, PHICE(JSEA),      &
                       TAUOCX(JSEA), TAUOCY(JSEA), WNMEAN(JSEA),   &
@@ -2759,6 +2761,7 @@
                             TAUOX(JSEA), TAUOY(JSEA), TAUWIX(JSEA),     &
                             TAUWIY(JSEA), TAUWNX(JSEA),                 &
                             TAUWNY(JSEA),  PHIAW(JSEA), CHARN(JSEA),    &
+                            Z0(JSEA), USTAR2(JSEA),                     &
                             TWS(JSEA), PHIOC(JSEA), TMP1, D50, PSIC,TMP2,&
                             PHIBBL(JSEA), TMP3, TMP4 , PHICE(JSEA),     &
                             TAUOCX(JSEA), TAUOCY(JSEA), WNMEAN(JSEA),   &


### PR DESCRIPTION
# Pull Request Summary
This PR adds surface roughness and friction velocity to the output fields from WW3, both of which are required for wave-momentum coupling in E3SM. 


